### PR TITLE
:recycle: Refactor: JWT 토큰 전달 방식을 쿠키 기반으로 변경

### DIFF
--- a/src/main/java/com/skthon/sixthsensebe/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/skthon/sixthsensebe/domain/auth/controller/AuthController.java
@@ -26,13 +26,12 @@ public class AuthController {
 
   @Operation(
       summary = "로그인",
-      description =
+      description = """
+            아이디/비밀번호로 로그인합니다.
+            - 성공 시: accessToken/refreshToken 모두 **HttpOnly 쿠키**로 전달됩니다.
+            - 응답 바디에는 로그인한 사용자 정보가 포함됩니다.
           """
-              아이디와 비밀번호로 로그인을 수행합니다.
-              
-              - 성공 시: 액세스 토큰은 헤더(**Authorization**)로, 리프레시 토큰은 **HttpOnly 쿠키**로 전달됩니다.
-              - 응답 바디에는 로그인한 사용자의 기본 정보가 포함됩니다.
-              """)
+  )
   @PostMapping("/login")
   public ResponseEntity<BaseResponse<UserResponse>> login(
       @Valid @RequestBody UserRequest.LoginRequest loginRequest, HttpServletResponse response) {
@@ -66,14 +65,11 @@ public class AuthController {
 
   @Operation(
       summary = "액세스 토큰 재발급",
-      description =
+      description = """
+            쿠키의 refreshToken을 검증하여 **새로운 accessToken을 HttpOnly 쿠키**로 재발급합니다.
+            - Redis 저장 토큰과 일치할 때만 성공합니다.
           """
-              저장된 리프레시 토큰을 기반으로 새로운 액세스 토큰을 재발급합니다.
-              - 요청 시 **쿠키에 저장된 refreshToken**을 사용합니다.
-              - Redis에 저장된 토큰과 일치하는 경우에만 재발급이 성공합니다.
-              - 응답 헤더의 Authorization 값으로 새로운 액세스 토큰이 전달됩니다.
-              - 본 API는 **로그인 후 액세스 토큰이 만료된 경우에 사용**합니다.
-              """)
+  )
   @PostMapping("/refresh")
   public ResponseEntity<BaseResponse<String>> reissueAccessToken(
       HttpServletRequest request, HttpServletResponse response) {
@@ -84,15 +80,11 @@ public class AuthController {
 
   @Operation(
       summary = "로그아웃",
-      description =
+      description = """
+            쿠키의 accessToken을 블랙리스트에 등록하고, Redis의 refreshToken을 삭제합니다.
+            - 브라우저의 accessToken/refreshToken 쿠키를 즉시 만료시킵니다.
           """
-              현재 로그인된 사용자를 로그아웃 처리합니다.
-              
-              - 요청 헤더의 **Authorization**에서 액세스 토큰을 추출하여 로그아웃 처리합니다.
-              - 액세스 토큰은 Redis 블랙리스트에 등록되어 만료 전까지 사용이 차단됩니다.
-              - 리프레시 토큰은 Redis에서 삭제되며, **브라우저 쿠키에서도 제거**됩니다.
-              - 응답 바디는 별도의 데이터 없이 로그아웃 성공 메시지만 반환됩니다.
-              """)
+  )
   @PostMapping("/logout")
   public ResponseEntity<BaseResponse<Void>> logout(
       HttpServletRequest request, HttpServletResponse response) {

--- a/src/main/java/com/skthon/sixthsensebe/domain/auth/service/AuthService.java
+++ b/src/main/java/com/skthon/sixthsensebe/domain/auth/service/AuthService.java
@@ -34,6 +34,10 @@ public class AuthService {
   private final RedisUtil redisUtil;
   private final UserMapper userMapper;
   private final UserService userService;
+
+  private static final String ACCESS_TOKEN_COOKIE = "accessToken";
+  private static final String REFRESH_TOKEN_COOKIE = "refreshToken";
+  private static final String REDIS_BLACKLIST_PREFIX = "blacklist:";
   private static final String REFRESH_TOKEN_PREFIX = "user:refresh:";
 
   @Value("${cookie.secure}")
@@ -71,61 +75,81 @@ public class AuthService {
   /**
    * 로그아웃 처리 메서드
    *
-   * <p>요청 헤더에서 액세스 토큰을 추출하여 Redis 블랙리스트에 저장하고, 리프레시 토큰을 Redis에서 삭제하여 재사용을 차단합니다.
+   * <p>쿠키에 저장된 액세스 토큰을 검증하여 Redis 블랙리스트에 등록하고,
+   * 사용자 리프레시 토큰을 Redis에서 삭제한 뒤 브라우저의 액세스/리프레시 쿠키를 즉시 만료시킨다.
    *
-   * @param request  HTTP 요청 객체 (헤더에서 Access Token 추출용)
-   * @param response HTTP 응답 객체 (리프레시 쿠키 삭제용)
-   * @throws CustomException 액세스 토큰이 유효하지 않거나 없을 경우 {@link AuthErrorCode#INVALID_ACCESS_TOKEN}
+   * <ul>
+   *   <li>Access Token: 쿠키에서 추출 → 유효성 검증 → 블랙리스트 등록(만료 시각까지)</li>
+   *   <li>Refresh Token: Redis 저장값 삭제 → 브라우저 쿠키 삭제</li>
+   *   <li>쿠키 정리: accessToken / refreshToken 둘 다 Max-Age=0 으로 무효화</li>
+   * </ul>
+   *
+   * @param response HTTP 응답 객체 (accessToken/refreshToken 쿠키 만료 설정용)
+   * @throws CustomException 액세스 토큰이 없거나 유효하지 않은 경우 {@link AuthErrorCode#INVALID_ACCESS_TOKEN}
    */
+  private void deleteAccessTokenCookie(HttpServletResponse response) {
+    ResponseCookie.ResponseCookieBuilder cookie =
+        ResponseCookie.from("accessToken", "")
+            .httpOnly(true)
+            .path("/")
+            .maxAge(Duration.ZERO);
+
+    if (secure) {
+      cookie.secure(true).sameSite("None");
+    } else {
+      cookie.secure(false).sameSite("Lax");
+    }
+
+    response.addHeader(HttpHeaders.SET_COOKIE, cookie.build().toString());
+  }
+
   public void logout(HttpServletRequest request, HttpServletResponse response) {
-    String accessToken = resolveAccessToken(request);
+    String accessToken = extractCookie(request, ACCESS_TOKEN_COOKIE); // 상수 사용
     if (accessToken == null || !jwtProvider.validateToken(accessToken)) {
       throw new CustomException(AuthErrorCode.INVALID_ACCESS_TOKEN);
     }
 
-    // 블랙리스트 등록 (accessToken → "logout" 값, 만료시간까지)
     long expiration =
         jwtProvider.extractExpiration(accessToken).getTime() - System.currentTimeMillis();
-    redisUtil.setData("blacklist:" + accessToken, "logout", expiration / 1000);
+    redisUtil.setData(REDIS_BLACKLIST_PREFIX + accessToken, "logout", expiration / 1000);
 
-    // refresh 토큰 Redis에서 삭제
     Long userId = jwtProvider.extractUserId(accessToken);
-    redisUtil.deleteData("user:refresh:" + userId);
+    redisUtil.deleteData(REFRESH_TOKEN_PREFIX + userId);
 
-    // 쿠키에서 refreshToken 제거
     deleteRefreshTokenCookie(response);
+    deleteAccessTokenCookie(response);
+  }
+
+  private String extractCookie(HttpServletRequest request, String name) {
+    if (request.getCookies() == null) {
+      return null;
+    }
+    for (Cookie cookie : request.getCookies()) {
+      if (name.equals(cookie.getName())) {
+        return cookie.getValue();
+      }
+    }
+    return null;
   }
 
   /**
-   * 액세스 토큰 재발급 처리 메서드
-   *
-   * <p>쿠키에서 리프레시 토큰을 추출한 후 Redis에 저장된 토큰과 비교하여 유효성을 검증합니다. 검증에 성공하면 새로운 액세스 토큰을 생성하여 응답 헤더에
-   * 포함시킵니다.
-   *
-   * @param request  HTTP 요청 객체 (쿠키에서 리프레시 토큰 추출용)
-   * @param response HTTP 응답 객체 (새로운 액세스 토큰 설정용)
-   * @throws CustomException 리프레시 토큰이 없거나 유효하지 않거나, 저장된 토큰과 일치하지 않는 경우
-   *                         {@link AuthErrorCode#REFRESH_TOKEN_REQUIRED}
+   * 액세스 토큰 재발급 - 쿠키의 refreshToken 검증 → 새 accessToken 발급
    */
   public void reissueAccessToken(HttpServletRequest request, HttpServletResponse response) {
-    // 1. 쿠키에서 refreshToken 추출
     String refreshToken = extractRefreshTokenFromCookie(request);
     if (refreshToken == null || !jwtProvider.validateToken(refreshToken)) {
       throw new CustomException(AuthErrorCode.REFRESH_TOKEN_REQUIRED);
     }
 
-    // 2. 사용자 ID 추출
     Long userId = jwtProvider.extractUserId(refreshToken);
-
-    // 3. Redis에 저장된 리프레시 토큰과 비교
-    String storedToken = redisUtil.getData("user:refresh:" + userId);
+    String storedToken = redisUtil.getData(REFRESH_TOKEN_PREFIX + userId);
     if (!refreshToken.equals(storedToken)) {
       throw new CustomException(AuthErrorCode.REFRESH_TOKEN_REQUIRED);
     }
 
-    // 4. 새로운 accessToken 생성 후 응답 헤더에 설정
+    // 새 accessToken을 쿠키로 내려줌 (헤더 X)
     String newAccessToken = jwtProvider.createAccessToken(userId);
-    response.setHeader("Authorization", "Bearer " + newAccessToken);
+    setAccessTokenCookie(response, newAccessToken, jwtProvider.getAccessTokenExpireTime() / 1000);
   }
 
   // 사용자 인증
@@ -149,22 +173,33 @@ public class AuthService {
     long refreshTokenExpireSeconds = jwtProvider.getRefreshTokenExpireTime() / 1000;
     redisUtil.setData(REFRESH_TOKEN_PREFIX + user.getId(), refreshToken, refreshTokenExpireSeconds);
 
-    setAccessTokenHeader(response, accessToken);
+    setAccessTokenCookie(response, accessToken, jwtProvider.getAccessTokenExpireTime() / 1000);
     setRefreshTokenCookie(response, refreshToken, refreshTokenExpireSeconds);
 
     return userMapper.toResponse(user);
   }
 
-  private void setAccessTokenHeader(HttpServletResponse response, String accessToken) {
-    response.setHeader("Authorization", "Bearer " + accessToken);
+  private void setAccessTokenCookie(HttpServletResponse response, String accessToken,
+      long maxAgeSec) {
+    ResponseCookie.ResponseCookieBuilder cookie =
+        ResponseCookie.from(ACCESS_TOKEN_COOKIE, accessToken)
+            .httpOnly(true)       // XSS에 안전
+            .path("/")
+            .maxAge(Duration.ofSeconds(maxAgeSec));
+
+    if (secure) {
+      cookie.secure(true).sameSite("None"); // 크로스 도메인일 때
+    } else {
+      cookie.secure(false).sameSite("Lax"); // 로컬 개발
+    }
+    response.addHeader(HttpHeaders.SET_COOKIE, cookie.build().toString());
   }
 
   // 토큰 쿠키 설정
-  private void setRefreshTokenCookie(
-      HttpServletResponse response, String refreshToken, long maxAgeSec) {
-
+  private void setRefreshTokenCookie(HttpServletResponse response, String refreshToken,
+      long maxAgeSec) {
     ResponseCookie.ResponseCookieBuilder cookie =
-        ResponseCookie.from("refreshToken", refreshToken)
+        ResponseCookie.from(REFRESH_TOKEN_COOKIE, refreshToken)
             .httpOnly(true)
             .path("/")
             .maxAge(Duration.ofSeconds(maxAgeSec));
@@ -172,7 +207,6 @@ public class AuthService {
     if (secure) {
       cookie.secure(true).sameSite("None");
     } else {
-      // 로컬 개발환경
       cookie.secure(false).sameSite("Lax");
     }
 
@@ -200,9 +234,13 @@ public class AuthService {
     return null;
   }
 
+
   private void deleteRefreshTokenCookie(HttpServletResponse response) {
     ResponseCookie.ResponseCookieBuilder cookie =
-        ResponseCookie.from("refreshToken", "").httpOnly(true).path("/").maxAge(Duration.ZERO);
+        ResponseCookie.from(REFRESH_TOKEN_COOKIE, "")
+            .httpOnly(true)
+            .path("/")
+            .maxAge(Duration.ZERO);
 
     if (secure) {
       cookie.secure(true).sameSite("None");

--- a/src/main/java/com/skthon/sixthsensebe/domain/user/controller/UserController.java
+++ b/src/main/java/com/skthon/sixthsensebe/domain/user/controller/UserController.java
@@ -16,17 +16,24 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
+import java.time.LocalDate;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
-
-import java.time.LocalDate;
-import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
@@ -36,13 +43,26 @@ public class UserController {
 
   private final UserService userService;
   private final JwtProvider jwtProvider;
+  private static final String ACCESS_TOKEN_COOKIE = "accessToken";
 
   private Long currentUserId(HttpServletRequest request) {
-    String bearer = request.getHeader("Authorization");
-    if (bearer != null && bearer.startsWith("Bearer ")) {
-      return jwtProvider.extractUserId(bearer.substring(7));
+    String token = extractCookie(request, ACCESS_TOKEN_COOKIE);
+    if (token != null) {
+      return jwtProvider.extractUserId(token);
     }
     throw new CustomException(UserErrorCode.USER_NOT_FOUND);
+  }
+
+  private String extractCookie(HttpServletRequest request, String name) {
+    if (request.getCookies() == null) {
+      return null;
+    }
+    for (var c : request.getCookies()) {
+      if (name.equals(c.getName())) {
+        return c.getValue();
+      }
+    }
+    return null;
   }
 
   // 회원가입


### PR DESCRIPTION
## 📝 요약(Summary)

<!--- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->
- JWT 인증 전달 방식을 Header → HttpOnly Cookie 기반으로 변경
- AuthController, AuthService, UserController 수정
- accessToken/refreshToken 쿠키 발급 및 검증 로직 적용

## 🛠️ PR 유형

어떤 변경 사항이 있나요?

- [x] 코드 리팩토링
- [x] 문서 수정


## 📸스크린샷 (선택)

## 💬 공유사항 to 리뷰어

<!--- 리뷰어가 중점적으로 봐줬으면 좋겠는 부분이 있으면 적어주세요. -->
<!--- 논의해야할 부분이 있다면 적어주세요.-->
<!--- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->

## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
